### PR TITLE
chore(refactor) move instagram feed template into reusable component

### DIFF
--- a/packages/commercetools/theme/components/InstagramFeed.vue
+++ b/packages/commercetools/theme/components/InstagramFeed.vue
@@ -1,0 +1,65 @@
+<template>
+  <SfSection title-heading="Share Your Look" subtitle-heading="#YOURLOOK" class="section">
+    <div class="grid grid-images">
+      <div class="grid__row">
+        <div class="grid__col">
+          <SfImage src="/homepage/imageA.jpg">katherina_trn</SfImage>
+        </div>
+        <div class="grid__col">
+          <SfImage src="/homepage/imageB.jpg">katherina_trn</SfImage>
+        </div>
+      </div>
+      <div class="grid__row">
+        <div class="grid__col">
+          <SfImage src="/homepage/imageC.jpg">katherina_trn</SfImage>
+        </div>
+        <div class="grid__col">
+          <SfImage src="/homepage/imageD.jpg">katherina_trn</SfImage>
+        </div>
+      </div>
+    </div>
+  </SfSection>
+</template>
+<script>
+import {
+  SfSection,
+  SfImage
+} from "@storefront-ui/vue"
+export default {
+  name: "InstagramFeed",
+  components: {
+    SfSection,
+    SfImage
+  }
+}
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/shared/styles/variables";
+@mixin for-desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
+  }
+}
+.grid {
+  max-width: 960px;
+  margin: auto;
+  &__row {
+    display: flex;
+    & + & {
+      margin-top: $spacer-big / 2;
+      @include for-desktop {
+        margin-top: $spacer-big;
+      }
+    }
+  }
+  &__col {
+    margin: 0;
+    & + & {
+      margin-left: $spacer-big / 2;
+      @include for-desktop {
+        margin-left: $spacer-big;
+      }
+    }
+  }
+}
+</style>

--- a/packages/commercetools/theme/package.json
+++ b/packages/commercetools/theme/package.json
@@ -13,7 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@storefront-ui/vue": "file:../../../../storefront-ui/packages/vue",
+    "@storefront-ui/vue": "^0.5.1",
     "@vue-storefront/commercetools-api": "^0.0.1",
     "@vue-storefront/commercetools-composables": "^0.0.1",
     "@vue-storefront/commercetools-helpers": "^0.0.1",

--- a/packages/commercetools/theme/pages/Category.vue
+++ b/packages/commercetools/theme/pages/Category.vue
@@ -491,6 +491,7 @@ export default {
   &__list {
     display: flex;
     flex-wrap: wrap;
+    margin-top: 1.875rem - 0.5rem;
   }
   &__product-card {
     flex: 0 0 50%;
@@ -535,13 +536,6 @@ export default {
     font-size: inherit;
   }
 }
-
-.filters_sidebar {
-  .sf-sidebar__aside {
-
-  }
-}
-
 .filters {
   &__title {
     margin: $spacer-big * 3 0 $spacer-big;

--- a/packages/commercetools/theme/pages/Product.vue
+++ b/packages/commercetools/theme/pages/Product.vue
@@ -190,48 +190,7 @@
         </SfCarouselItem>
       </SfCarousel>
     </SfSection>
-    <SfSection
-      title-heading="Share Your Look"
-      subtitle-heading="#YOURLOOK"
-      class="section"
-    >
-      <div class="images-grid">
-        <div class="images-grid__row">
-          <div class="images-grid__col">
-            <SfImage src="/homepage/imageA.jpg"
-              >katherina_trn</SfImage
-            >
-          </div>
-          <div class="images-grid__col">
-            <SfImage src="/homepage/imageB.jpg"
-              >katherina_trn</SfImage
-            >
-          </div>
-          <div class="images-grid__col">
-            <SfImage src="/homepage/imageC.jpg"
-              >katherina_trn</SfImage
-            >
-          </div>
-        </div>
-        <div class="images-grid__row">
-          <div class="images-grid__col">
-            <SfImage src="/homepage/imageC.jpg"
-              >katherina_trn</SfImage
-            >
-          </div>
-          <div class="images-grid__col">
-            <SfImage src="/homepage/imageD.jpg"
-              >katherina_trn</SfImage
-            >
-          </div>
-          <div class="images-grid__col">
-            <SfImage src="/homepage/imageA.jpg"
-              >katherina_trn</SfImage
-            >
-          </div>
-        </div>
-      </div>
-    </SfSection>
+    <InstagramFeed />
     <SfBanner
       title="Download our application to your mobile"
       image="/homepage/bannerD.png"
@@ -282,7 +241,8 @@ import {
   SfSticky,
   SfReview,
   SfBreadcrumbs
-} from "@storefront-ui/vue";
+} from '@storefront-ui/vue'
+import InstagramFeed from '~/components/InstagramFeed.vue'
 import { ref, computed } from '@vue/composition-api'
 
 import { useProduct, useCart } from '@vue-storefront/commercetools-composables'
@@ -310,15 +270,15 @@ export default {
 
     const attributes = computed(() => getProductAttributes(product.value))
 
-    return { 
+    return {
       product,
       attributes,
       getProductName,
       getProductPrice,
       getProductGallery,
-      qty, 
-      addToCart, 
-      loading 
+      qty,
+      addToCart,
+      loading
     }
   },
   components: {
@@ -339,7 +299,8 @@ export default {
     SfBanner,
     SfSticky,
     SfReview,
-    SfBreadcrumbs
+    SfBreadcrumbs,
+    InstagramFeed
   },
   data() {
     return {
@@ -558,26 +519,6 @@ export default {
   }
   ::v-deep .sf-gallery__stage {
     width: 100%;
-  }
-}
-.images-grid {
-  &__row {
-    display: flex;
-    & + & {
-      margin-top: $spacer-big / 2;
-      @include for-desktop {
-        margin-top: $spacer-big;
-      }
-    }
-  }
-  &__col {
-    margin: 0;
-    & + & {
-      margin-left: $spacer-big / 2;
-      @include for-desktop {
-        margin-left: $spacer-big;
-      }
-    }
   }
 }
 .product {

--- a/packages/commercetools/theme/pages/index.vue
+++ b/packages/commercetools/theme/pages/index.vue
@@ -82,38 +82,7 @@
         </SfCarouselItem>
       </SfCarousel>
     </SfSection>
-    <SfSection
-      title-heading="Share Your Look"
-      subtitle-heading="#YOURLOOK"
-      class="section"
-    >
-      <div class="grid grid-images">
-        <div class="grid__row">
-          <div class="grid__col">
-            <SfImage src="/homepage/imageA.jpg"
-              >katherina_trn</SfImage
-            >
-          </div>
-          <div class="grid__col">
-            <SfImage src="/homepage/imageB.jpg"
-              >katherina_trn</SfImage
-            >
-          </div>
-        </div>
-        <div class="grid__row">
-          <div class="grid__col">
-            <SfImage src="/homepage/imageC.jpg"
-              >katherina_trn</SfImage
-            >
-          </div>
-          <div class="grid__col">
-            <SfImage src="/homepage/imageD.jpg"
-              >katherina_trn</SfImage
-            >
-          </div>
-        </div>
-      </div>
-    </SfSection>
+    <InstagramFeed />
     <SfBanner
       image="/homepage/bannerD.png"
       class="banner-application desktop-only"
@@ -154,7 +123,8 @@ import {
   SfProductCard,
   SfImage,
   SfBannerGrid
-} from "@storefront-ui/vue";
+} from "@storefront-ui/vue"
+import InstagramFeed from "~/components/InstagramFeed.vue"
 
 export default {
   name: "Home",
@@ -254,7 +224,8 @@ export default {
     SfCarousel,
     SfProductCard,
     SfImage,
-    SfBannerGrid
+    SfBannerGrid,
+    InstagramFeed
   }
 };
 </script>
@@ -331,28 +302,6 @@ export default {
   margin: $spacer-big 0;
   @include for-desktop {
     margin: $spacer-extra-big 0;
-  }
-}
-.grid {
-  max-width: 960px;
-  margin: auto;
-  &__row {
-    display: flex;
-    & + & {
-      margin-top: $spacer-big / 2;
-      @include for-desktop {
-        margin-top: $spacer-big;
-      }
-    }
-  }
-  &__col {
-    margin: 0;
-    & + & {
-      margin-left: $spacer-big / 2;
-      @include for-desktop {
-        margin-left: $spacer-big;
-      }
-    }
   }
 }
 .sf-banner {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,16 +1862,18 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@storefront-ui/shared@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@storefront-ui/shared/-/shared-0.4.0.tgz#fcc9a9557a77de008ddb8ea8ae619e8df1a7e5ff"
-  integrity sha512-GnapplNTw39OftUSKMjLLaur1eE5rLJqHnTPUIgI5v9UlZEWW8NrU6UrogFiseWVen0oz+XprQ/xEZsS5Im6+w==
+"@storefront-ui/shared@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@storefront-ui/shared/-/shared-0.5.1.tgz#313cf978470e43cf7a1af401d65617eb496f6ba4"
+  integrity sha512-WhyhVug+RDyxlVq4Beb46OD6jePnHBz3luSj2NbTUAhDGWWcnr6GcaGJALdtxSIcl58lyr11wnHSD+aE+a7c1A==
 
-"@storefront-ui/vue@file:../storefront-ui/packages/vue":
-  version "0.4.0"
+"@storefront-ui/vue@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@storefront-ui/vue/-/vue-0.5.1.tgz#62c69d204232bd4050beb01963829fc4a4fbf751"
+  integrity sha512-ocuZNggS9oEyuXhYHjshJSfHQQ0iSUrFPWPz5ijG3Q1Af9c/GXZ0NPG/agPehRynpgiCOkMsZzPtbU8FK4+u4g==
   dependencies:
     "@glidejs/glide" "^3.3.0"
-    "@storefront-ui/shared" "^0.4.0"
+    "@storefront-ui/shared" "^0.5.1"
     "@vue/babel-preset-app" "^4.0.0-alpha.1"
     body-scroll-lock "^2.6.4"
     core-js "^3.1.3"


### PR DESCRIPTION
- get the markup out into separate file
- use the extracted markup in home and product pages
- Closes #79 
- use vsfui 0.5.1 instead of local version