### PR TITLE
Fix double-path when compiling the templates causing empty templates generated

### DIFF
--- a/packages/core/theme-module/index.js
+++ b/packages/core/theme-module/index.js
@@ -34,7 +34,7 @@ module.exports = function DefaultThemeModule(moduleOptions) {
   const compileAgnosticTemplates = () => {
     themeFiles.forEach((file) => {
       compileTemplates(
-        path.join(__dirname, file),
+        file,
         this.options.buildDir.split('.nuxt').pop() + '.theme/' + file.split('theme/').pop(),
         {
           apiClient: moduleOptions.apiClient,


### PR DESCRIPTION
The path is joined already in line 20 and 22 by (dirPath + '/' + file)

yarn build:dev doesn't trigger an error during the build because compileTemplates.js use asynchronous readFile and writeFile, otherwise it would trigger the error like this:

> FATAL  ENOENT: no such file or directory, open 'D:\projects\vue-storefront\packages\core\theme-module\D:\projects\vue-storefront\packages\core\theme-module\theme\assets\css\reset.scss' 

- [x] I Accept [Individual Contributor License Agreement](https://github.com/DivanteLtd/next/blob/master/CLA.md)
