### PR TITLE
fix: lerna duplicated core workspace error

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
       "packages/commercetools/*",
       "packages/boilerplate/*",
       "packages/core/*",
-      "packages/core/core",
       "packages/prismic",
       "packages/about-you/*"
     ],


### PR DESCRIPTION
- [x] I'm confirming that if i made any changes to public APIs or exposed any public APIs they are doccumented.

This fixes the following error:
![image](https://user-images.githubusercontent.com/46789227/79308508-02f83980-7ef9-11ea-9a73-1af66c89fc56.png)
