### PR TITLE
fix: add missing theme directories to boilerplate and AYC

### DIFF
--- a/packages/about-you/theme/components/README.md
+++ b/packages/about-you/theme/components/README.md
@@ -1,0 +1,1 @@
+Put here theme-specific components to override default ones

--- a/packages/about-you/theme/helpers/README.md
+++ b/packages/about-you/theme/helpers/README.md
@@ -1,0 +1,1 @@
+Put here platform-specific, non-agnostic functions that overwrite default code.

--- a/packages/boilerplate/theme/components/README.md
+++ b/packages/boilerplate/theme/components/README.md
@@ -1,0 +1,1 @@
+Put here theme-specific components to override default ones

--- a/packages/boilerplate/theme/helpers/README.md
+++ b/packages/boilerplate/theme/helpers/README.md
@@ -1,0 +1,1 @@
+Put here platform-specific, non-agnostic functions that overwrite default code.

--- a/packages/core/theme-module/index.js
+++ b/packages/core/theme-module/index.js
@@ -24,8 +24,6 @@ module.exports = async function DefaultThemeModule(moduleOptions) {
   const themeHelpersDir = path.join(this.options.rootDir, 'helpers');
   const themeFiles = getAllFilesFromDir(baseThemeDir).filter(file => !file.includes('/static/'));
 
-  console.log(themeFiles);
-
   const compileAgnosticTemplate = (filePath) => {
     return compileTemplate(
       path.join(__dirname, filePath),


### PR DESCRIPTION
- [ ] I'm confirming that if i made any changes to public APIs or exposed any public APIs they are doccumented.