### PR TITLE
refactor: move search result interfaces to factories

### DIFF
--- a/packages/about-you/composables/src/composables/useUserOrders/index.ts
+++ b/packages/about-you/composables/src/composables/useUserOrders/index.ts
@@ -1,14 +1,13 @@
 /* istanbul ignore file */
 
-import { useUserOrdersFactory, UseUserOrdersFactoryParams } from '@vue-storefront/core';
+import { useUserOrdersFactory, UseUserOrdersFactoryParams, OrdersSearchResult } from '@vue-storefront/core';
 import { BapiOrder, BapiOrderSearchParams } from '../../types';
-import { SearchResult } from '@vue-storefront/core';
 
 // @todo userOrders
 
 const params: UseUserOrdersFactoryParams<BapiOrder, BapiOrderSearchParams> = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  searchOrders: async (params: BapiOrderSearchParams = {}): Promise<SearchResult<BapiOrder>> => new Promise(() => ({}))
+  searchOrders: async (params: BapiOrderSearchParams = {}): Promise<OrdersSearchResult<BapiOrder>> => new Promise(() => ({}))
 };
 
 const useUserOrders: () => any = useUserOrdersFactory<BapiOrder, BapiOrderSearchParams>(params);

--- a/packages/about-you/composables/src/helpers/mapProductSearch.ts
+++ b/packages/about-you/composables/src/helpers/mapProductSearch.ts
@@ -1,8 +1,8 @@
-import { SearchResult } from '@vue-storefront/core';
 import { getProduct } from '@vue-storefront/about-you-api';
 import { BapiProduct } from '@aboutyou/backbone/types/BapiProduct';
+import { ProductsSearchResult } from '@vue-storefront/core';
 
-const mapProductSearch = async (params): Promise<SearchResult<BapiProduct>> => {
+const mapProductSearch = async (params): Promise<ProductsSearchResult<BapiProduct>> => {
   const searchParams = {
     ids: params.ids,
     with: params.term,

--- a/packages/commercetools/composables/src/useProduct/index.ts
+++ b/packages/commercetools/composables/src/useProduct/index.ts
@@ -1,8 +1,7 @@
 import { getProduct } from '@vue-storefront/commercetools-api';
 import { enhanceProduct, mapPaginationParams } from './../helpers/internals';
 import { ProductVariant } from './../types/GraphQL';
-import { useProductFactory } from '@vue-storefront/core';
-import { SearchResult } from '@vue-storefront/core';
+import { useProductFactory, ProductsSearchResult } from '@vue-storefront/core';
 
 const productsSearch = async (params: {
   perPage?: number;
@@ -14,7 +13,7 @@ const productsSearch = async (params: {
   skus?: string[];
   slug?: string;
   id?: string;
-}): Promise<SearchResult<ProductVariant>> => {
+}): Promise<ProductsSearchResult<ProductVariant>> => {
   const apiSearchParams = {
     ...params,
     ...mapPaginationParams(params)

--- a/packages/commercetools/composables/src/useUserOrders/index.ts
+++ b/packages/commercetools/composables/src/useUserOrders/index.ts
@@ -1,11 +1,10 @@
-import { useUserOrdersFactory, UseUserOrdersFactoryParams } from '@vue-storefront/core';
+import { useUserOrdersFactory, UseUserOrdersFactoryParams, OrdersSearchResult } from '@vue-storefront/core';
 import { Order } from '../types/GraphQL';
 import { OrderSearchParams } from '../types';
 import { getMyOrders } from '@vue-storefront/commercetools-api';
-import { SearchResult } from '@vue-storefront/core';
 
 const params: UseUserOrdersFactoryParams<Order, OrderSearchParams> = {
-  searchOrders: async (params: OrderSearchParams = {}): Promise<SearchResult<Order>> => {
+  searchOrders: async (params: OrderSearchParams = {}): Promise<OrdersSearchResult<Order>> => {
     const result = await getMyOrders(params);
     const { results: data, total } = result.data?.me.orders || { results: [], total: 0 };
     return { data, total };

--- a/packages/core/core/__tests__/factories/useUserOrdersFactory.spec.ts
+++ b/packages/core/core/__tests__/factories/useUserOrdersFactory.spec.ts
@@ -1,5 +1,5 @@
-import { UseUserOrders, SearchResult } from '../../src/types';
-import { UseUserOrdersFactoryParams, useUserOrdersFactory } from '../../src/factories';
+import { UseUserOrders } from '../../src/types';
+import { UseUserOrdersFactoryParams, useUserOrdersFactory, OrdersSearchResult } from '../../src/factories';
 import { Ref } from '@vue/composition-api';
 import * as vsfUtils from '../../src/utils';
 
@@ -7,7 +7,7 @@ jest.mock('../../src/utils');
 const mockedUtils = vsfUtils as jest.Mocked<typeof vsfUtils>;
 mockedUtils.onSSR.mockImplementation((fn) => fn());
 
-let useUserOrders: () => UseUserOrders<Readonly<Ref<Readonly<SearchResult<any>>>>>;
+let useUserOrders: () => UseUserOrders<Readonly<Ref<Readonly<OrdersSearchResult<any>>>>>;
 let params: UseUserOrdersFactoryParams<any, any>;
 
 function createComposable(): void {

--- a/packages/core/core/src/factories/useProductFactory.ts
+++ b/packages/core/core/src/factories/useProductFactory.ts
@@ -1,4 +1,4 @@
-import { UseProduct, SearchResult } from '../types';
+import { UseProduct } from '../types';
 import { ref, Ref, computed } from '@vue/composition-api';
 import { useSSR } from '../utils';
 
@@ -10,8 +10,13 @@ type SearchParams = {
   filters?: any;
 }
 
+export interface ProductsSearchResult<PRODUCT> {
+  data: PRODUCT[];
+  total: number;
+}
+
 export type UseProductFactoryParams<PRODUCT, PRODUCT_SEARCH_PARAMS extends SearchParams> = {
-  productsSearch: (searchParams: PRODUCT_SEARCH_PARAMS) => Promise<SearchResult<PRODUCT>>;
+  productsSearch: (searchParams: PRODUCT_SEARCH_PARAMS) => Promise<ProductsSearchResult<PRODUCT>>;
 };
 
 export function useProductFactory<PRODUCT, PRODUCT_SEARCH_PARAMS>(

--- a/packages/core/core/src/factories/useUserOrdersFactory.ts
+++ b/packages/core/core/src/factories/useUserOrdersFactory.ts
@@ -1,9 +1,14 @@
 import { ref, Ref, computed } from '@vue/composition-api';
-import { UseUserOrders, SearchResult } from '../types';
+import { UseUserOrders } from '../types';
 import { useSSR } from '../../src/utils';
 
+export interface OrdersSearchResult<ORDER> {
+  data: ORDER[];
+  total: number;
+}
+
 export type UseUserOrdersFactoryParams<ORDER, ORDER_SEARCH_PARAMS> = {
-  searchOrders: (params: ORDER_SEARCH_PARAMS) => Promise<SearchResult<ORDER>>;
+  searchOrders: (params: ORDER_SEARCH_PARAMS) => Promise<OrdersSearchResult<ORDER>>;
 };
 
 export function useUserOrdersFactory<ORDER, ORDER_SEARCH_PARAMS>(factoryParams: UseUserOrdersFactoryParams<ORDER, ORDER_SEARCH_PARAMS>) {

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -257,11 +257,6 @@ export interface AgnosticProductReview {
   rating: number | null;
 }
 
-export interface SearchResult<T> {
-  data: T[];
-  total: number;
-}
-
 export interface AgnosticLocale {
   code: string;
   label: string;


### PR DESCRIPTION
Goal of this PR: de-DRY interfaces for search results in different factories.

- [x] I'm confirming that if i made any changes to public APIs or exposed any public APIs they are doccumented.